### PR TITLE
do not use GNU Assembler on Microsoft Windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -87,6 +87,14 @@ fn main() {
         _ => {
             println!("cargo:rerun-if-changed=dynamorio");
 
+            #[cfg(target_os = "windows")]
+            let mut path = cmake::Config::new("dynamorio")
+                .define("BUILD_DOCS", "NO")
+                .build_target(BUILD_TARGET)
+                .profile("RelWithDebInfo")
+                .build();
+
+            #[cfg(target_os = "linux")]
             let mut path = cmake::Config::new("dynamorio")
                 .define("BUILD_DOCS", "NO")
                 .define("CMAKE_ASM_COMPILER", "/usr/bin/as")


### PR DESCRIPTION
Do not define CMAKE_ASM_COMPILER and CMAKE_ASM_FLAGS on Microsoft Windows.