### PR TITLE
Fix build failure on gcc-15

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -272,6 +272,7 @@ fn main() {
     println!("cargo:rerun-if-changed=src/wrapper.c");
 
     cc::Build::new()
+        .std("c99")
         .define(PLATFORM, None)
         .define(ARCHITECTURE, None)
         .include(build_dir.join("include"))


### PR DESCRIPTION
DR uses its own `bool` definition and has not transitioned to `stdbool.h`. We need to specify c99 for the build to pass. This issue has been discussed [here](https://github.com/DynamoRIO/dynamorio/issues/7493) and fixed the same way upstream.