### PR TITLE
Update bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ x = []
 
 [build-dependencies]
 regex = "1"
-bindgen = "0.71"
+bindgen = "0.72"
 cc = "1"
 cmake = "0.1"
 

--- a/build.rs
+++ b/build.rs
@@ -272,6 +272,7 @@ fn main() {
     println!("cargo:rerun-if-changed=src/wrapper.c");
 
     cc::Build::new()
+        .std("c99")
         .define(PLATFORM, None)
         .define(ARCHITECTURE, None)
         .include(build_dir.join("include"))


### PR DESCRIPTION
This is a head-scratcher. I updated to Fedora 44, which somehow caused bindgen `v0.71` to mis-generate some DynamoRIO structures. `dynamorio-sys` fails to compile due to this bug. I don't see anything in the bindgen release notes between `v0.72` and `v0.71` that may be relevant, but upgrading to bindgen `v0.72` fixes this issue. I suspect it has something to do with the gcc-15 to 16 update.